### PR TITLE
Fix: 이미지 파일 경로값이 empty인 경우 조건 추가

### DIFF
--- a/lib/apis.dart
+++ b/lib/apis.dart
@@ -103,7 +103,7 @@ class APIs {
     request.fields['name'] = member.name!;
 
     // FormData 파일 필드 추가
-    if (member.profileImage != null) {
+    if (member.profileImage != null && member.profileImage != '') {
       var file = await http.MultipartFile.fromPath(
         'profileImage',
         member.profileImage!

--- a/lib/apis.dart
+++ b/lib/apis.dart
@@ -103,7 +103,7 @@ class APIs {
     request.fields['name'] = member.name!;
 
     // FormData 파일 필드 추가
-    if (member.profileImage != null && member.profileImage != '') {
+    if (member.profileImage != null && member.profileImage!.isNotEmpty) {
       var file = await http.MultipartFile.fromPath(
         'profileImage',
         member.profileImage!


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #58 
- 파일 업로드를 하지 않았을 시 SignUpModel profileImage에 ''인 경로가 들어가더군요!
- 파일을 업로드한걸로 인식해서, request시에 http 패키지가 multipartFile 객체를 만들지 못하고 오류를 발생시키는 것을 확인했습니다.(from jenny)
<img width="576" alt="image" src="https://github.com/4Ailen/frontend/assets/87576669/5431b782-5681-44b2-9880-e4f8f5bbdb4d">


## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 조건문에 member.profileImage != ' ' 추가 했습니다.
- 사진이 없을 경우 회원가입 되는 것 확인했습니다!

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 자바에서 쓰는 것처럼 문자열 관련해서는 명확하게 member.profileImage.isNotEmpty()를 쓰고 싶었는데 
- member.profileImage!.isNotEmpty()
- member.profileImage?.isNotEmpty()
모두 빨간줄로 안되더군요.. 다트를 잘 몰라서 왜 안되는지 궁금하긴한데, 프론트 분들 중 혹시 아시는 분 있으시면 알려주세요..
