### PR TITLE
Feat/#76 chat token 채팅 인증 로직 추가

### DIFF
--- a/lib/apis/apis.dart
+++ b/lib/apis/apis.dart
@@ -710,5 +710,31 @@ class APIs {
     }
   }
 
+  // 채팅 토큰 받아오기
+  static Future<String> getChatToken() async {
+    var _url = 'http://13.125.205.59:8080/api/v1/chat/token';
+    //토큰 읽어오기
+    var jwtToken = await storage.read(key: 'token');
 
+    //accessToken만 보내기
+    jwtToken = json.decode(jwtToken!)['accessToken'];
+
+    var response = await http.get(
+      Uri.parse(_url),
+      headers: {
+        'Authorization': 'Bearer $jwtToken',
+        'Content-Type': 'application/json'
+      },
+    );
+
+    //success
+    if (response.statusCode == 200) {
+      return json.decode(utf8.decode(response.bodyBytes))['data'];
+
+      //fail
+    } else {
+      print(json.decode(utf8.decode(response.bodyBytes))['message']);
+      throw Exception('요청 오류');
+    }
+  }
 }

--- a/lib/apis/apis.dart
+++ b/lib/apis/apis.dart
@@ -418,7 +418,7 @@ class APIs {
 
   //상대 정보 요청
   static Future<List<Partner>> getApplicantPartners() async {
-    const url = 'http://192.168.221.201:8080/api/v1/matching/partners';
+    const url = 'http://13.125.205.59:8080/api/v1/matching/partners';
 
     //토큰 읽어오기
     var jwtToken = await storage.read(key: 'token');

--- a/lib/mockdatas/mockdata_model.dart
+++ b/lib/mockdatas/mockdata_model.dart
@@ -177,7 +177,7 @@ ScreenArguments mockScreenArgument_2 = ScreenArguments(
     [
       Partner(
           roomState: "OPEN",
-          roomId: 1,
+          roomId: 43,
           name: '파트너1',
           nationality: 'South Korea',
           gender: 'FEMALE',

--- a/lib/views/pages/chatting/chatting_page.dart
+++ b/lib/views/pages/chatting/chatting_page.dart
@@ -210,19 +210,29 @@ class _ChattingPageState extends State<ChattingPage> {
   final FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
   StreamSubscription<RemoteMessage>? _messageStreamSubscription;
 
+
+  void connectWebSocket() async {
+    String chatToken = await APIs.getChatToken();
+
+    final wsUrl = Uri.parse('ws://13.125.205.59:8082/ws/chat/message/send');
+    final wsReadUrl = Uri.parse('ws://13.125.205.59:8082/ws/chat/message/read');
+    final wsAllReadUrl = Uri.parse('ws://13.125.205.59:8082/ws/chat/room/read');
+
+    var header = {
+      'Authorization': chatToken
+    };
+
+    channel = IOWebSocketChannel.connect(wsUrl, headers: header);
+    readChannel = IOWebSocketChannel.connect(wsReadUrl, headers: header);
+    allReadChannel = IOWebSocketChannel.connect(wsAllReadUrl, headers: header);
+  }
+
   @override
   void initState() {
     super.initState();
     createdDate = DateTime.now().toString();
 
-    final wsUrl = Uri.parse('ws://13.125.205.59:8081/ws/chat');
-    final wsReadUrl = Uri.parse('ws://13.125.205.59:8081/ws/read');
-    final wsAllReadUrl = Uri.parse('ws://13.125.205.59:8081/ws/room');
-
-
-    channel = IOWebSocketChannel.connect(wsUrl);
-    readChannel = IOWebSocketChannel.connect(wsReadUrl);
-    allReadChannel = IOWebSocketChannel.connect(wsAllReadUrl);
+    connectWebSocket();
 
     var initializationSettingsAndroid = AndroidInitializationSettings('@mipmap/ic_launcher');
     //var initializationSettingsIOS = IOSInitializationSettings();
@@ -264,6 +274,7 @@ class _ChattingPageState extends State<ChattingPage> {
               //'fcmToken': "dGMgDEHjQ02mFoAse9E9M2:APA91bE993Xpeg5v29-mzNgEhJ5usLzw3OOGnMXMawT5WYNu1I9MVyYzKuTqgXAZpSfc0xQcEPQTxtzP1OgsVc2c8Q0TNbxV-N-uBlDkh2AoEu-6UqFYo78UXVOWMBnZ47RbZ-rxlL79",
               'fcmToken': "fxfKtVLpSSS9Wpsffoj64l:APA91bG2iCjrWsm8VV9XH4UD4bOPq7Ox1dEU7vwXc1gKMZ2JV2suNuGo9Wxggye7EYrAMfpHRE7i5j3mWTBD2Ig3MgyOQa4rin5QzZMVRwtIhRwHNIsLOjpiYD69G9ZT03-oJqv0eHVQ",
               'chatId': message.data['chatId'],
+              'roomId': message.data['roomId'],
             };
             //웹소켓 전송
             await readChannel.sink.add(json.encode(request));

--- a/lib/views/pages/login/login_page.dart
+++ b/lib/views/pages/login/login_page.dart
@@ -27,8 +27,8 @@ class Login extends StatefulWidget {
 class _LoginState extends State<Login> {
   final GlobalKey<FormState> _emailFormKey = GlobalKey<FormState>();
   final GlobalKey<FormState> _pwFormKey = GlobalKey<FormState>();
-  final TextEditingController _emailController = TextEditingController();
-  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController(text: 'cju4103@pukyong.ac.kr');
+  final TextEditingController _passwordController = TextEditingController(text: '1234567');
 
   //storage에 작성할 모델
   final Auth auth = new Auth();


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #76 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- APIs/getChatToken() 추가
- chatting_page.dart에서 각 웹소켓 연결시 헤더에 Authorization 속성 추가
- 단일 읽음 처리시 요청에 roomId 속성 추가
- 기타 테스트용 수정사항 있습니다

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 기존 채팅 서버(8081 포트)와 별개로 인증 로직 추가 버전(8082 포트)을 함께 올려뒀습니다
- 해당 URL통해서 요청할 경우 정상적으로 인증 로직 동작하는것 확인했습니다!
- roomId가 유효하지 않을 경우 다음과 같이 응답이 오며 소켓 연결이 끊깁니다. 이후 구현에 참고하시면됩니다!
<img width="1104" alt="image" src="https://github.com/4Ailen/frontend/assets/87576669/3b498e22-c842-40db-ab34-af621301cad2">
